### PR TITLE
feat: refonte pipeline CD — GHCR + semantic versioning via Convention…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ DB_ROOT_PASSWORD=change_me_root  # Requis par MariaDB dans docker-compose — no
 JWT_SECRET=minimum_32_characters_secret_change_me_in_production
 JWT_EXPIRY=15m
 REFRESH_TOKEN_EXPIRY_DAYS=30
+
+
+# Version de l'image Docker à déployer (tag GHCR)
+# Utiliser 'latest' pour la dernière release, ou fixer une version (ex: 1.2.0) pour pincer
+DASHBOARD_VERSION=latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,60 +1,114 @@
-name: CD
+name: Release
 
 on:
   push:
     branches: [main]
-
-# Secrets requis dans les paramètres du dépôt GitHub :
-# SSH_HOST        : adresse IP ou hostname du serveur
-# SSH_USERNAME    : utilisateur SSH (ex: deploy, ubuntu, manu)
-# SSH_PRIVATE_KEY : clé privée RSA/Ed25519 (contenu complet du fichier id_rsa ou id_ed25519)
-# DEPLOY_PATH     : chemin absolu du répertoire du projet sur le serveur (ex: /home/manu/dashboard)
+    # Un merge de PR dans main déclenche l'événement "push" côté GitHub Actions.
+    # La branch protection garantit que seuls les merges de PR depuis develop arrivent ici.
 
 concurrency:
-  group: cd-main
-  cancel-in-progress: false
+  group: release-main
+  cancel-in-progress: false   # jamais annuler une release en cours
 
 permissions:
-  contents: read
+  contents: write   # push commit + tag + GitHub Release
+  packages: write   # push images sur GHCR
 
 jobs:
-  deploy:
-    name: Déploiement SSH
+  release:
+    name: Bump · Build · Publish
     runs-on: ubuntu-latest
 
     steps:
-      - name: Valider les secrets requis
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0                        # historique complet pour l'analyse des commits
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # ── 1. Calculer la nouvelle version ─────────────────────────────────────
+      - name: Calculer la version
+        id: version
         run: |
-          missing=()
-          [[ -z "$SSH_HOST" ]] && missing+=("SSH_HOST")
-          [[ -z "$SSH_USERNAME" ]] && missing+=("SSH_USERNAME")
-          [[ -z "$SSH_PRIVATE_KEY" ]] && missing+=("SSH_PRIVATE_KEY")
-          [[ -z "$DEPLOY_PATH" ]] && missing+=("DEPLOY_PATH")
-          if [[ ${#missing[@]} -gt 0 ]]; then
-            echo "::error::Secrets manquants : ${missing[*]}"
-            exit 1
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          CURRENT=$(echo "$LAST_TAG" | sed 's/^v//')
+
+          # Analyser les commits depuis le dernier tag
+          COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%s")
+
+          if echo "$COMMITS" | grep -qE "^feat!:|BREAKING CHANGE"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "^feat:"; then
+            BUMP="minor"
+          else
+            BUMP="patch"   # fix:, chore:, refactor:, docs: ou pas de CC → patch par défaut
           fi
 
-      - name: Configurer la clé SSH
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-        run: |
-          mkdir -p ~/.ssh
-          printf '%s' "$SSH_PRIVATE_KEY" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          NEW=$(npx --yes semver -i "$BUMP" "$CURRENT")
+          echo "version=$NEW"    >> $GITHUB_OUTPUT
+          echo "tag=v$NEW"       >> $GITHUB_OUTPUT
+          echo "bump=$BUMP"      >> $GITHUB_OUTPUT
+          echo "📦 $CURRENT → $NEW ($BUMP)"
 
-      - name: Déployer sur le serveur
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
-          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      # ── 2. Bumper package.json et committer sur main ─────────────────────────
+      - name: Bumper package.json
         run: |
-          ssh -i ~/.ssh/id_deploy "$SSH_USERNAME@$SSH_HOST" \
-            "cd '$DEPLOY_PATH' && git pull --ff-only origin main && docker-compose up -d --build"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          git add package.json
+          git commit -m "chore: release ${{ steps.version.outputs.tag }} [skip ci]"
+          git push
+
+      # ── 3. Créer le tag git ──────────────────────────────────────────────────
+      - name: Créer le tag
+        run: |
+          git tag ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin ${{ steps.version.outputs.tag }}
+
+      # ── 4. Login GHCR ────────────────────────────────────────────────────────
+      - name: Login GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      # ── 5. Build & Push backend ──────────────────────────────────────────────
+      - name: Build & Push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/dashboard-backend:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/dashboard-backend:latest
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+
+      # ── 6. Build & Push frontend ─────────────────────────────────────────────
+      - name: Build & Push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/dashboard-frontend:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/dashboard-frontend:latest
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
+
+      # ── 7. GitHub Release ────────────────────────────────────────────────────
+      - name: Créer la GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.version.outputs.tag }} \
+            --generate-notes \
+            --title "Dashboard ${{ steps.version.outputs.tag }}" \
+            --latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
     name: E2E — Playwright (Chromium)
     runs-on: ubuntu-latest
     needs: [frontend, backend]
+    # E2E uniquement au merge dans develop (push), pas sur les PRs de feature
+    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v4
@@ -91,12 +93,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: e2e/package-lock.json
 
-      - name: Créer backend/.env pour CI
+      - name: Créer .env pour CI
         env:
           ADMIN_USERNAME: ${{ secrets.E2E_ADMIN_USERNAME }}
           ADMIN_INITIAL_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
         run: |
-          cat > backend/.env <<'ENVFILE'
+          # Fichier à la racine du projet — docker-compose.yml utilise env_file: .env
+          cat > .env <<'ENVFILE'
           PORT=3000
           DB_HOST=db
           DB_PORT=3306
@@ -108,8 +111,8 @@ jobs:
           JWT_EXPIRES_IN=15m
           REFRESH_TOKEN_EXPIRES_IN=7d
           ENVFILE
-          printf 'ADMIN_USERNAME=%s\n' "$ADMIN_USERNAME" >> backend/.env
-          printf 'ADMIN_INITIAL_PASSWORD=%s\n' "$ADMIN_INITIAL_PASSWORD" >> backend/.env
+          printf 'ADMIN_USERNAME=%s\n' "$ADMIN_USERNAME" >> .env
+          printf 'ADMIN_INITIAL_PASSWORD=%s\n' "$ADMIN_INITIAL_PASSWORD" >> .env
 
       - name: Démarrer la stack
         run: docker compose -f docker-compose.yml up -d

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,15 +1,24 @@
+# docker-compose.override.yml — Dev local uniquement (jamais déployé en production)
+# Docker Compose merge ce fichier automatiquement avec docker-compose.yml en développement.
+# Pour la production uniquement : docker compose -f docker-compose.yml up
 services:
   backend:
     build:
       context: ./backend
       target: builder
+    image: ""
     volumes:
       - ./backend:/app
       - /app/node_modules
     command: npm run start:dev
     ports:
-      - "127.0.0.1:3000:3000"
+      - "3000:3000"
+
+  frontend:
+    build:
+      context: ./frontend
+    image: ""
 
   db:
     ports:
-      - "127.0.0.1:3306:3306"
+      - "3306:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,8 @@ services:
       retries: 5
 
   backend:
-    build:
-      context: ./backend
-    env_file: backend/.env
+    image: ghcr.io/manurobate/dashboard-backend:${DASHBOARD_VERSION:-latest}
+    env_file: .env
     depends_on:
       db:
         condition: service_healthy
@@ -36,8 +35,7 @@ services:
       retries: 3
 
   frontend:
-    build:
-      context: ./frontend
+    image: ghcr.io/manurobate/dashboard-frontend:${DASHBOARD_VERSION:-latest}
     depends_on:
       backend:
         condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "devDependencies": {
-    "@types/node": "^25.7.0"
-  }
+  "name": "dashboard",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Dashboard personnel auto-hébergé — version carrier pour le pipeline CD"
 }


### PR DESCRIPTION
…al Commits

- Remplace le déploiement SSH par un pipeline de release GHCR
- Bump semver automatique via Conventional Commits (fix/feat/feat!)
- package.json racine comme version carrier (v0.0.0 → vX.Y.Z)
- docker-compose.yml : images GHCR, backup Story 1.7 conservé, env_file racine
- docker-compose.override.yml : build local avec hot-reload
- ci.yml : E2E uniquement au merge dans develop (if: push) + .env à la racine
- Ajout DASHBOARD_VERSION=latest dans .env.example