### PR TITLE
fix: remove package.json bump step and silence Node 20 warnings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,11 @@ concurrency:
   cancel-in-progress: false   # jamais annuler une release en cours
 
 permissions:
-  contents: write   # push commit + tag + GitHub Release
+  contents: write   # push tag + GitHub Release
   packages: write   # push images sur GHCR
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   release:
@@ -53,23 +56,13 @@ jobs:
           echo "bump=$BUMP"      >> $GITHUB_OUTPUT
           echo "📦 $CURRENT → $NEW ($BUMP)"
 
-      # ── 2. Bumper package.json et committer sur main ─────────────────────────
-      - name: Bumper package.json
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
-          git add package.json
-          git commit -m "chore: release ${{ steps.version.outputs.tag }} [skip ci]"
-          git push
-
-      # ── 3. Créer le tag git ──────────────────────────────────────────────────
+      # ── 2. Créer le tag git ──────────────────────────────────────────────────
       - name: Créer le tag
         run: |
           git tag ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
           git push origin ${{ steps.version.outputs.tag }}
 
-      # ── 4. Login GHCR ────────────────────────────────────────────────────────
+      # ── 3. Login GHCR ────────────────────────────────────────────────────────
       - name: Login GHCR
         uses: docker/login-action@v3
         with:
@@ -79,7 +72,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      # ── 5. Build & Push backend ──────────────────────────────────────────────
+      # ── 4. Build & Push backend ──────────────────────────────────────────────
       - name: Build & Push backend
         uses: docker/build-push-action@v5
         with:
@@ -91,7 +84,7 @@ jobs:
           cache-from: type=gha
           cache-to:   type=gha,mode=max
 
-      # ── 6. Build & Push frontend ─────────────────────────────────────────────
+      # ── 5. Build & Push frontend ─────────────────────────────────────────────
       - name: Build & Push frontend
         uses: docker/build-push-action@v5
         with:
@@ -103,7 +96,7 @@ jobs:
           cache-from: type=gha
           cache-to:   type=gha,mode=max
 
-      # ── 7. GitHub Release ────────────────────────────────────────────────────
+      # ── 6. GitHub Release ────────────────────────────────────────────────────
       - name: Créer la GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   backend:
     name: Backend — Lint + Tests


### PR DESCRIPTION
- remove package.json commit-back step from CD pipeline (github-actions[bot] blocked by branch protection on main)
- add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to ci.yml and cd.yml to silence actions/checkout@v4 and actions/setup-node@v4 deprecation