### PR TITLE
fix: add git identity config before creating annotated tag

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,8 @@ jobs:
       # ── 2. Créer le tag git ──────────────────────────────────────────────────
       - name: Créer le tag
         run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
           git push origin ${{ steps.version.outputs.tag }}
 


### PR DESCRIPTION
Removed with the package.json bump step — annotated tags require a committer identity.